### PR TITLE
NVCS Configuration Tool v1.4.0

### DIFF
--- a/nvcs-client/package.json
+++ b/nvcs-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nvcs-configuration-tool",
   "productName": "NVCS Configuration Tool",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "NVCS Configuration Tool",
   "main": "src/index.js",
   "scripts": {

--- a/nvcs-dev/nvcs/key_western_us.py
+++ b/nvcs-dev/nvcs/key_western_us.py
@@ -5,7 +5,7 @@ from pattern import PatternList
 import logging
 
 class Plot:
-    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation):
+    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive):
         self.attrs = dict()
         self.attrs['ident'] = ident
         self.attrs['rscd'] = rscd
@@ -15,6 +15,7 @@ class Plot:
         self.attrs['hydric'] = hydric
         self.attrs['riverine'] = riverine
         self.attrs['elevation'] = float(elevation)
+        self.attrs['balive'] = float(balive)
         self.trees = list()
 
     def __getattr__(self, name):
@@ -50,6 +51,10 @@ class Plot:
     def get_elevation(self):
         logging.debug('%s|elevation()|%s', self.ident, self.elevation)
         return int(self.elevation)
+
+    def get_balive(self):
+        logging.debug('%s|balive()|%s', self.ident, self.balive)
+        return float(self.balive)
 
     def __repr__(self):
         return "Plot(%r)" % (self.attrs)

--- a/nvcs-dev/nvcs/key_western_us.py
+++ b/nvcs-dev/nvcs/key_western_us.py
@@ -69,7 +69,7 @@ class Plot:
         logging.debug('%s|grcov()|%s', self.ident, self.grcov)
         return float(self.grcov)
 
-    def get_shcovv(self):
+    def get_shcov(self):
         logging.debug('%s|shcov()|%s', self.ident, self.shcov)
         return float(self.shcov)
 

--- a/nvcs-dev/nvcs/key_western_us.py
+++ b/nvcs-dev/nvcs/key_western_us.py
@@ -5,7 +5,7 @@ from pattern import PatternList
 import logging
 
 class Plot:
-    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive):
+    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive, fbcov, grcov, shcov, ttcov, ntcov):
         self.attrs = dict()
         self.attrs['ident'] = ident
         self.attrs['rscd'] = rscd
@@ -16,6 +16,11 @@ class Plot:
         self.attrs['riverine'] = riverine
         self.attrs['elevation'] = float(elevation)
         self.attrs['balive'] = float(balive)
+        self.attrs['fbcov'] = float(fbcov or 0)
+        self.attrs['grcov'] = float(grcov or 0)
+        self.attrs['shcov'] = float(shcov or 0)
+        self.attrs['ttcov'] = float(ttcov or 0)
+        self.attrs['ntcov'] = float(ntcov or 0)
         self.trees = list()
 
     def __getattr__(self, name):
@@ -55,6 +60,26 @@ class Plot:
     def get_balive(self):
         logging.debug('%s|balive()|%s', self.ident, self.balive)
         return float(self.balive)
+
+    def get_fbcov(self):
+        logging.debug('%s|fbcov()|%s', self.ident, self.fbcov)
+        return float(self.fbcov)
+
+    def get_grcov(self):
+        logging.debug('%s|grcov()|%s', self.ident, self.grcov)
+        return float(self.grcov)
+
+    def get_shcovv(self):
+        logging.debug('%s|shcov()|%s', self.ident, self.shcov)
+        return float(self.shcov)
+
+    def get_ttcov(self):
+        logging.debug('%s|ttcov()|%s', self.ident, self.ttcov)
+        return float(self.ttcov)
+
+    def get_ntcov(self):
+        logging.debug('%s|ntcov()|%s', self.ident, self.ntcov)
+        return float(self.ntcov)
 
     def __repr__(self):
         return "Plot(%r)" % (self.attrs)

--- a/nvcs-dev/nvcs_builder/builder.py
+++ b/nvcs-dev/nvcs_builder/builder.py
@@ -33,6 +33,11 @@ class ElementBuilder:
         else:
             trigger = re.sub(r'(elevation)\s*\(\s*\)', r'plot.get_\1()', trigger)
             trigger = re.sub(r'(balive)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(fbcov)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(grcov)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(shcov)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(ttcov)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(ntcov)\s*\(\s*\)', r'plot.get_\1()', trigger)
             trigger = re.sub(r'(match)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)
             trigger = re.sub(r'(riv)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)
             trigger = re.sub(r'(spcov)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)

--- a/nvcs-dev/nvcs_builder/builder.py
+++ b/nvcs-dev/nvcs_builder/builder.py
@@ -32,6 +32,7 @@ class ElementBuilder:
             trigger = 'False'
         else:
             trigger = re.sub(r'(elevation)\s*\(\s*\)', r'plot.get_\1()', trigger)
+            trigger = re.sub(r'(balive)\s*\(\s*\)', r'plot.get_\1()', trigger)
             trigger = re.sub(r'(match)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)
             trigger = re.sub(r'(riv)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)
             trigger = re.sub(r'(spcov)\s*\(\s*([0-9a-zA-Z_]+)\s*\)', r'plot.\1(\2)', trigger)

--- a/nvcs-dev/nvcs_config/template-classification-key.py
+++ b/nvcs-dev/nvcs_config/template-classification-key.py
@@ -5,7 +5,7 @@ from pattern import PatternList
 import logging
 
 class Plot:
-    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation):
+    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive):
         self.attrs = dict()
         self.attrs['ident'] = ident
         self.attrs['rscd'] = rscd
@@ -15,6 +15,7 @@ class Plot:
         self.attrs['hydric'] = hydric
         self.attrs['riverine'] = riverine
         self.attrs['elevation'] = float(elevation)
+        self.attrs['balive'] = float(balive)
         self.trees = list()
 
     def __getattr__(self, name):
@@ -50,6 +51,10 @@ class Plot:
     def get_elevation(self):
         logging.debug('%s|elevation()|%s', self.ident, self.elevation)
         return int(self.elevation)
+
+    def get_balive(self):
+        logging.debug('%s|balive()|%s', self.ident, self.balive)
+        return float(self.balive)
 
     def __repr__(self):
         return "Plot(%r)" % (self.attrs)

--- a/nvcs-dev/nvcs_config/template-classification-key.py
+++ b/nvcs-dev/nvcs_config/template-classification-key.py
@@ -69,7 +69,7 @@ class Plot:
         logging.debug('%s|grcov()|%s', self.ident, self.grcov)
         return float(self.grcov)
 
-    def get_shcovv(self):
+    def get_shcov(self):
         logging.debug('%s|shcov()|%s', self.ident, self.shcov)
         return float(self.shcov)
 

--- a/nvcs-dev/nvcs_config/template-classification-key.py
+++ b/nvcs-dev/nvcs_config/template-classification-key.py
@@ -5,7 +5,7 @@ from pattern import PatternList
 import logging
 
 class Plot:
-    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive):
+    def __init__(self, ident, rscd, state, ecoregion, plantation, hydric, riverine, elevation, balive, fbcov, grcov, shcov, ttcov, ntcov):
         self.attrs = dict()
         self.attrs['ident'] = ident
         self.attrs['rscd'] = rscd
@@ -16,6 +16,11 @@ class Plot:
         self.attrs['riverine'] = riverine
         self.attrs['elevation'] = float(elevation)
         self.attrs['balive'] = float(balive)
+        self.attrs['fbcov'] = float(fbcov or 0)
+        self.attrs['grcov'] = float(grcov or 0)
+        self.attrs['shcov'] = float(shcov or 0)
+        self.attrs['ttcov'] = float(ttcov or 0)
+        self.attrs['ntcov'] = float(ntcov or 0)
         self.trees = list()
 
     def __getattr__(self, name):
@@ -55,6 +60,26 @@ class Plot:
     def get_balive(self):
         logging.debug('%s|balive()|%s', self.ident, self.balive)
         return float(self.balive)
+
+    def get_fbcov(self):
+        logging.debug('%s|fbcov()|%s', self.ident, self.fbcov)
+        return float(self.fbcov)
+
+    def get_grcov(self):
+        logging.debug('%s|grcov()|%s', self.ident, self.grcov)
+        return float(self.grcov)
+
+    def get_shcovv(self):
+        logging.debug('%s|shcov()|%s', self.ident, self.shcov)
+        return float(self.shcov)
+
+    def get_ttcov(self):
+        logging.debug('%s|ttcov()|%s', self.ident, self.ttcov)
+        return float(self.ttcov)
+
+    def get_ntcov(self):
+        logging.debug('%s|ntcov()|%s', self.ident, self.ntcov)
+        return float(self.ntcov)
 
     def __repr__(self):
         return "Plot(%r)" % (self.attrs)

--- a/nvcs-dev/nvcs_tester/full_output.py
+++ b/nvcs-dev/nvcs_tester/full_output.py
@@ -100,7 +100,7 @@ def generateFullOutput(in_ClassificationKey, in_KeyTestData, in_AnlyTestData, in
         python_key_input_vw_definition = (
             f"CREATE VIEW '{python_key_input_vw_name}' AS "
             "SELECT IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, "
-            "ELEVATION, SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, "
+            "ELEVATION, BALIVE, SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, "
             f"TALLYTREE, SPCOV FROM {in_KeyTestData['new_tbl_nm']} "
             f"WHERE INVYR = {inventory_year}{additional_where_clause};"
         )

--- a/nvcs-dev/nvcs_tester/full_output.py
+++ b/nvcs-dev/nvcs_tester/full_output.py
@@ -100,7 +100,7 @@ def generateFullOutput(in_ClassificationKey, in_KeyTestData, in_AnlyTestData, in
         python_key_input_vw_definition = (
             f"CREATE VIEW '{python_key_input_vw_name}' AS "
             "SELECT IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, "
-            "ELEVATION, BALIVE, SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, "
+            "ELEVATION, BALIVE, FBCOV, GRCOV, SHCOV, TTCOV, NTCOV, SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, "
             f"TALLYTREE, SPCOV FROM {in_KeyTestData['new_tbl_nm']} "
             f"WHERE INVYR = {inventory_year}{additional_where_clause};"
         )

--- a/nvcs-dev/nvcs_tester/plot_io.py
+++ b/nvcs-dev/nvcs_tester/plot_io.py
@@ -44,7 +44,7 @@ def read_csv(file_path):
 def read_sqlite(dbfile, tbl):
     from key_western_us import Plot
     from key_western_us import Tree
-    plot_fields = 'IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, ELEVATION'
+    plot_fields = 'IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, ELEVATION, BALIVE'
     tree_fields = 'SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, TALLYTREE, SPCOV'
     sql = 'SELECT DISTINCT ' + plot_fields + ' FROM ' + tbl
     sql = sql + ' WHERE STATEAB != "AK"'

--- a/nvcs-dev/nvcs_tester/plot_io.py
+++ b/nvcs-dev/nvcs_tester/plot_io.py
@@ -44,7 +44,7 @@ def read_csv(file_path):
 def read_sqlite(dbfile, tbl):
     from key_western_us import Plot
     from key_western_us import Tree
-    plot_fields = 'IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, ELEVATION, BALIVE'
+    plot_fields = 'IDENT, RSCD, STATEAB, ECOREGION, PLANTATION, HYDRIC, RIVERINE, ELEVATION, BALIVE, FBCOV, GRCOV, SHCOV, TTCOV, NTCOV'
     tree_fields = 'SPECIES, RIV, WETLAND, RUDERAL, EXOTIC, SOFTWOODHARDWOOD, PLANTED, TALLYTREE, SPCOV'
     sql = 'SELECT DISTINCT ' + plot_fields + ' FROM ' + tbl
     sql = sql + ' WHERE STATEAB != "AK"'


### PR DESCRIPTION
This pull request updates the Python classifier to support some new plot-level columns sourced from the analytical dataset now included into the test dataset:
- BALIVE (via `balive()`)
- FBCOV (via `fbcov()`)
- GRCOV (via `grcov()`)
- TTCOV (via `ttcov()`)
- NTCOV (via `ntcov()`)

An example of these in use for a node trigger:
```
match(ECOREGIONS) and grcov() >= 30
```